### PR TITLE
Terminology update

### DIFF
--- a/docs/terminology/general-terminology.md
+++ b/docs/terminology/general-terminology.md
@@ -129,11 +129,11 @@ m/z tolerance is defined as maximum allowed difference between m/z values in ord
 
 ## References
 
-- Pluskal, T., Castillo, S., Villar-Briones, A. & Oresic, M. MZmine 2: Modular framework for processing, visualizing, and analyzing mass spectrometry-based molecular profile data. _BMC Bioinformatics_ (2010). DOI: [10.1186/1471-2105-11-395](https://doi.org/10.1186/1471-2105-11-395)
-- Pluskal, T. et al. Processing Metabolomics and Proteomics Data with Open Software: A Practical Guide, Chapter 7: Metabolomics Data Analysis Using MZmine (2020). DOI: [10.1039/9781788019880-00232](https://doi.org/10.1039/9781788019880-00232)
-- Smoluch M., Piechura K. Mass Spectrometry: An Applied Approach, Chapter 3: Basic Definitions (2019). DOI: [10.1002/9781119377368.ch3](https://onlinelibrary.wiley.com/doi/10.1002/9781119377368.ch3)
-- [IUPAC. Compendium of Chemical Terminology](https://doi.org/10.1351/goldbook), 2nd ed. (the "Gold Book"). Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific Publications, Oxford (1997). Online version (2019-) created by S. J. Chalk. ISBN 0-9678550-9-8. 
-- Guo, J., Huan T. Evaluation of significant features discovered from different data acquisition modes in mass spectrometry-based untargeted metabolomics. _Analytica Chimica Acta_ (2020). DOI: [10.1016/j.aca.2020.08.065](https://doi.org/10.1016/j.aca.2020.08.065)
+- Pluskal, T., Castillo, S., Villar-Briones, A. & Oresic, M. MZmine 2: Modular framework for processing, visualizing, and analyzing mass spectrometry-based molecular profile data. _BMC Bioinformatics_ (2010). DOI: <a>10.1186/1471-2105-11-395</a>
+- Pluskal, T. et al. Processing Metabolomics and Proteomics Data with Open Software: A Practical Guide, Chapter 7: Metabolomics Data Analysis Using MZmine (2020). DOI: <a>10.1039/9781788019880-00232</a>
+- Smoluch M., Piechura K. Mass Spectrometry: An Applied Approach, Chapter 3: Basic Definitions (2019). DOI: <a>10.1002/9781119377368.ch3</a>
+- IUPAC. Compendium of Chemical Terminology, 2nd ed. (the "Gold Book"). Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific Publications, Oxford (1997). Online version (2019-) created by S. J. Chalk. ISBN 0-9678550-9-8. <a>10.1351/goldbook</a>
+- Guo, J., Huan T. Evaluation of significant features discovered from different data acquisition modes in mass spectrometry-based untargeted metabolomics. _Analytica Chimica Acta_ (2020). DOI: <a>10.1016/j.aca.2020.08.065</a>
 
 
 

--- a/docs/terminology/ion-mobility-terminology.md
+++ b/docs/terminology/ion-mobility-terminology.md
@@ -33,7 +33,7 @@ In TWIMS, ions are propelled through a gas-filled stacked ring ion guide with th
 
 Higher mobility ions undergo less ‘roll over’ events on the waves than the lower mobility ions. As the waves pass along the device, ions can ‘surf’ on the wave front for a period of time before being overtaken by the wave. Usage of travelling waves makes possible to increase sensitivity, selectivity, and speed of the method.
 
-For more information, see [Fundamentals of Traveling Wave Ion Mobility Spectrometry](https://doi.org/10.1021%2Fac8016295)
+For more information, see _Fundamentals of Traveling Wave Ion Mobility Spectrometry_ DOI: <a>10.1021/ac8016295</a>
 
 ## Terminology
 

--- a/docs/terminology/ion-mobility-terminology.md
+++ b/docs/terminology/ion-mobility-terminology.md
@@ -66,7 +66,7 @@ An "_ion mobility trace_" basically represents a mobility resolved extracted ion
 **Collision cross section (CCS)** can be defined as area of interaction between an individual ion and gas molecule. CCS depends on ion's size, shape, and charge. IM-derived CCS values can be used as an additional molecular descriptor to support the compound unknown identification process.
 
 ## References
-- Meier, F., Brunner, A.D., Koch, S., Cox, J., Räther, O., Mann, M. Online Parallel Accumulation–Serial Fragmentation (PASEF) with a Novel Trapped Ion Mobility Mass Spectrometer. _Molecular & Cellular Proteomics_ (2018). DOI: [10.1074/mcp.TIR118.000900](https://doi.org/10.1074%2Fmcp.TIR118.000900)
-- Paglia, G. et al. Ion Mobility Derived Collision Cross Sections to Support Metabolomics Applications. _Anal. Chem._ (2014). DOI: [10.1021/ac500405x](https://doi.org/10.1021/ac500405x)
+- Meier, F., Brunner, A.D., Koch, S., Cox, J., Räther, O., Mann, M. Online Parallel Accumulation–Serial Fragmentation (PASEF) with a Novel Trapped Ion Mobility Mass Spectrometer. _Molecular & Cellular Proteomics_ (2018). DOI: <a>10.1074/mcp.TIR118.000900</a>
+- Paglia, G. et al. Ion Mobility Derived Collision Cross Sections to Support Metabolomics Applications. _Anal. Chem._ (2014). DOI: <a>10.1021/ac500405x</a>
 
 


### PR DESCRIPTION
Removing (for the moment) active URLs from references due to multiple **gaurav** link check failures due to the known issue - https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/127