### PR TITLE
Custom css & authors' contributions

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,9 @@
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+    color: #335183;
+    font-weight: bold;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,7 +158,7 @@ theme:
 plugins:
   - search
   - git-authors:
-      show_contribution: true
+      show_contribution: false
   - git-revision-date-localized:
       type: datetime
   - with-pdf:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,7 +146,10 @@ nav:
   - Acknowledgements: wikiacknowledgements.md
   - Changelog: changelog.md
 
-copyright: This documentation is licensed under the MIT License (MIT). 
+copyright: This documentation is licensed under the MIT License (MIT).
+
+extra_css:
+  - css/extra.css
 
 theme:
   name: material


### PR DESCRIPTION
This PR contains two minor changes:

- The custom css file was added to modify the style of the headers (bold is optional and can be removed). For purposes of better visibility, now the headers are rendered dark blue. This css can be further modified if we decide to introduce any changes.
- The percentages were removed from the authors' lists (but some names are duplicated now due to one person using different emails, etc.).